### PR TITLE
fix: split path string manually

### DIFF
--- a/src/util/regulation.rs
+++ b/src/util/regulation.rs
@@ -87,7 +87,6 @@ impl Regulation {
         let mut params: HashMap<Param, Vec<u8>> = HashMap::new();
 
         for file in &res.files {
-            let path = PathBuf::from_str(&file.name).unwrap();
             let file_name = path.file_stem().unwrap().to_str().unwrap().split("\\").last().expect("Could not find content at end of path");
             let param_type = Param::from_str(file_name)?;
             params.insert(param_type, file.bytes.to_vec());

--- a/src/util/regulation.rs
+++ b/src/util/regulation.rs
@@ -88,7 +88,7 @@ impl Regulation {
 
         for file in &res.files {
             let path = PathBuf::from_str(&file.name).unwrap();
-            let file_name = path.file_stem().unwrap().to_str().unwrap();
+            let file_name = path.file_stem().unwrap().to_str().unwrap().split("\\").last().expect("Could not find content at end of path");
             let param_type = Param::from_str(file_name)?;
             params.insert(param_type, file.bytes.to_vec());
         }


### PR DESCRIPTION
This should allow users on Linux to parse the virtual path correctly when loading a save file.