### PR TITLE
feat: add debug only stat importer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,8 @@ dependencies = [
  "once_cell",
  "rfd",
  "rust-embed",
+ "serde",
+ "serde_json",
  "strsim",
  "winres",
 ]
@@ -2091,6 +2093,12 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
@@ -3124,6 +3132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,6 +3189,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.49",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ miniz_oxide = "0.7.2"
 once_cell = "1.19.0"
 rfd = "0.13.0"
 rust-embed = "8.3.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 strsim = "0.11.0"
 
 [build-dependencies]

--- a/src/db/classes.rs
+++ b/src/db/classes.rs
@@ -36,6 +36,15 @@ pub mod classes {
         }
     }
 
+    impl TryFrom<String> for ArcheType {
+        type Error = ();
+        fn try_from(v: String) -> Result<Self, Self::Error> {
+            ArcheType::try_from(
+                (0..9).find(|enum_value| ArcheType::try_from(*enum_value).expect("").to_string() == v).expect("")
+            )
+        }
+    }
+
     impl ToString for ArcheType {
         fn to_string(&self) -> String {
             match self {

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -1,33 +1,22 @@
 pub mod stats {
-    use std::ops::RangeInclusive;
+    use std::{ops::RangeInclusive, path::PathBuf};
 
     use eframe::egui::{self, Ui};
     use egui_extras::{Column, TableBody, TableBuilder};
-    use crate::{db::classes::classes::STARTER_CLASSES, vm::vm::vm::ViewModel};
+    use rfd::FileDialog;
+    use crate::{db::classes::classes::STARTER_CLASSES, util::nya::nya::Model, vm::{stats::stats_view_model::StatsViewModel, vm::vm::ViewModel}};
 
     pub fn stats(ui: &mut Ui,  vm: &mut ViewModel) {
         egui::Frame::default()
         .show(ui, |ui| {
             ui.with_layout( egui::Layout::top_down_justified(egui::Align::Min),|ui|{
                 ui.with_layout(egui::Layout::top_down(egui::Align::Min), |ui|{
-
+                    #[cfg(debug_assertions)]
+                    import_stats(ui, vm);
                     ui.heading(vm.slots[vm.index].stats_vm.arche_type.to_string());
                     ui.add_space(8.0);
 
                     let class = &STARTER_CLASSES.lock().unwrap()[&vm.slots[vm.index].stats_vm.arche_type];
-
-                    // Calculate level from stats
-                    let level = 
-                        vm.slots[vm.index].stats_vm.vigor + 
-                        vm.slots[vm.index].stats_vm.mind + 
-                        vm.slots[vm.index].stats_vm.endurance + 
-                        vm.slots[vm.index].stats_vm.strength + 
-                        vm.slots[vm.index].stats_vm.dexterity + 
-                        vm.slots[vm.index].stats_vm.intelligence + 
-                        vm.slots[vm.index].stats_vm.faith + 
-                        vm.slots[vm.index].stats_vm.arcane-
-                        79;
-
 
                     let table = TableBuilder::new(ui)
                     .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
@@ -41,7 +30,16 @@ pub mod stats {
                             row.col(|ui| { 
                                 ui.label("Level:"); }); 
                             row.col(|ui| { 
-                                ui.label(format!("{:6}", level));
+                                ui.label(format!("{:6}", vm.slots[vm.index].stats_vm.level));
+                            });
+                        });
+                        
+                        // Acquired Runes
+                        body.row(24., |mut row| {
+                            row.col(|ui| { 
+                                ui.label("Acquired Runes:"); }); 
+                            row.col(|ui| { 
+                                ui.label(format!("{:6}", vm.slots[vm.index].stats_vm.soulsmemory));
                             });
                         });
                         
@@ -97,5 +95,22 @@ pub mod stats {
             row.col(|_| {
             });
         });
+    }
+
+    #[cfg(debug_assertions)]
+    fn import_stats(ui: &mut Ui,vm: &mut ViewModel) {
+        if ui.button(egui::RichText::new(format!("{} open", egui_phosphor::regular::FOLDER_OPEN))).clicked() {
+            let path = open_nya_file_dialog().expect("msg");
+            let model: Model = Model::from_json(path);
+            let stats_vm: StatsViewModel = StatsViewModel::from_nya_model(&model);
+            vm.slots[vm.index].stats_vm.try_update(stats_vm);
+        }
+    }
+
+    fn open_nya_file_dialog() -> Option<PathBuf> {
+        FileDialog::new()
+        .add_filter("JSON", &["json", "Nya JSON data"])
+        .set_directory("./")
+        .pick_file()
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,3 +5,4 @@ pub mod br_ext;
 pub mod param_structs;
 pub mod regulation;
 pub mod validator;
+pub mod nya;

--- a/src/util/nya.rs
+++ b/src/util/nya.rs
@@ -1,0 +1,51 @@
+pub mod nya {
+  use serde::Serialize;
+  use serde::Deserialize;
+  use std::fs::File;
+  use std::path::PathBuf;
+  use std::io::Read;
+
+
+  #[derive(Serialize, Deserialize, Debug)]
+  pub struct Stats {
+    #[serde(rename = "rl")]
+    pub level: u32,
+    #[serde(rename = "arc")]
+    pub arcane: u32,
+    #[serde(rename = "dex")]
+    pub dexterity: u32,
+    #[serde(rename = "fth")]
+    pub faith: u32,
+    #[serde(rename = "int")]
+    pub intelligence: u32,
+    #[serde(rename = "mnd")]
+    pub mind: u32,
+    #[serde(rename = "str")]
+    pub strength: u32,
+    #[serde(rename = "vig")]
+    pub vigor: u32,
+    #[serde(rename = "vit")]
+    pub endurance: u32
+  }
+
+  #[derive(Serialize, Deserialize, Debug)]
+    pub struct Model {
+      #[serde(rename = "characterClass")]
+      pub character_class: String,
+      pub stats: Stats,
+    }
+
+    impl Model {
+      pub fn from_json(path: PathBuf) -> Self {
+        let mut file = File::open(path).expect("Some file contents");
+        let mut contents = String::new();
+
+        file.read_to_string(&mut contents).expect("something");
+
+        // Deserialize the JSON into the Model struct
+        let model: Model = serde_json::from_str(&contents).expect("Could not create Model");
+
+        model
+      }
+    }
+  }

--- a/src/vm/stats.rs
+++ b/src/vm/stats.rs
@@ -1,4 +1,5 @@
 pub mod stats_view_model {
+    use crate::util::nya::nya;
     use crate::{db::classes::classes::ArcheType, save::common::save_slot::SaveSlot};
 
     #[derive(Clone)]
@@ -37,6 +38,21 @@ pub mod stats_view_model {
     }
 
     impl StatsViewModel {
+        pub fn try_update(&mut self, copy: Self) {
+            self.arche_type = copy.arche_type;
+
+            self.arcane = copy.arcane;
+            self.dexterity = copy.dexterity;
+            self.endurance = copy.endurance;
+            self.faith = copy.faith;
+            self.intelligence = copy.intelligence;
+            self.mind = copy.mind;
+            self.level = copy.level;
+            self.soulsmemory = copy.soulsmemory;
+            self.strength = copy.strength;
+            self.vigor = copy.vigor;
+        }
+
         pub fn from_save(slot:& SaveSlot) -> Self {
             let arche_type = ArcheType::try_from(slot.player_game_data.arche_type).expect("");
             let vigor = slot.player_game_data.vigor;
@@ -50,6 +66,36 @@ pub mod stats_view_model {
             let level = slot.player_game_data.level;
             let souls = slot.player_game_data.souls;
             let soulsmemory = slot.player_game_data.soulsmemory;
+
+            Self {
+                arche_type,
+                vigor,
+                mind,
+                endurance,
+                strength,
+                dexterity,
+                intelligence,
+                faith,
+                arcane,
+                level,
+                souls,
+                soulsmemory
+            }
+        }
+
+        pub fn from_nya_model(nyam: &nya::Model) -> Self {
+            let arche_type = ArcheType::try_from(nyam.character_class.clone()).expect("");
+            let vigor = nyam.stats.vigor;
+            let mind = nyam.stats.mind;
+            let endurance = nyam.stats.endurance;
+            let strength = nyam.stats.strength;
+            let dexterity = nyam.stats.dexterity;
+            let intelligence = nyam.stats.intelligence;
+            let faith = nyam.stats.faith;
+            let arcane = nyam.stats.arcane;
+            let level = nyam.stats.level;
+            let souls = Default::default();
+            let soulsmemory = Default::default();
 
             Self {
                 arche_type,


### PR DESCRIPTION
As a mule maker
I would like to be able to import Stat from [Nya](https://er-inventory.nyasu.business/)
So that I can use it to track all of my builds

<img width="958" alt="image" src="https://github.com/ClayAmore/ER-Save-Editor/assets/2087677/c719e0f4-ea03-4924-9b6f-6edfd7fd8d2d">
