### PR TITLE
Additional check for somber weapon level

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -225,9 +225,10 @@ pub mod vm {
                                 weapon_param.data.reinforceTypeId % 8500 == 0
                             );
                             
+                            let orginal_level = &((storage_item.item_id % 100) as u8);
                             // Extract weapon level based on wether weapon is somber or not
-                            let weapon_level = if is_somber{
-                                somber_to_normal[&((storage_item.item_id % 100) as u8)]
+                            let weapon_level = if is_somber && orginal_level <= &10{
+                                somber_to_normal[orginal_level]
                             }
                             else {
                                 (storage_item.item_id % 100) as u8


### PR DESCRIPTION
For ER-Save-Editor/src/vm/vm.rs, line: 219
```
let is_somber = weapon_param.data.reinforceTypeId != 0 && (
      weapon_param.data.reinforceTypeId % 2200 == 0 ||
      weapon_param.data.reinforceTypeId % 2400 == 0 ||
      weapon_param.data.reinforceTypeId % 3200 == 0 ||
      weapon_param.data.reinforceTypeId % 3300 == 0 ||
      weapon_param.data.reinforceTypeId % 8300 == 0 ||
      weapon_param.data.reinforceTypeId % 8500 == 0
);
```

I think this is not enough to check if weapon is somber, for some save data, non somber weapon reinforceTypeId could be 2200, weapon will be consider somber and break logic in line:229, because non somber level can be greater than 10, it cause key can't be found in hash error.

```
let weapon_level = if is_somber{
    somber_to_normal[&((storage_item.item_id % 100) as u8)]
}
```

I add another check, at least it will work for non-somber weapon with level > 10.
But it has problem for non-somber weapon with level <= 10.

Test:
cargo build
cargo run   