### PR TITLE
Fix save wizard file identification check

### DIFF
--- a/src/util/regulation.rs
+++ b/src/util/regulation.rs
@@ -87,10 +87,16 @@ impl Regulation {
         });
     }
 
-    pub fn params_from_regulation(bytes: &[u8]) -> Result<HashMap<Param, Vec<u8>>, Error>{
+    pub fn get_decrypted_decompressed(bytes: &[u8]) -> Result<BND4, Error>{
         let decrypted = Self::decrypt(&bytes)?;
         let decompressed = Self::decompress(&decrypted)?;
         let res = Self::unpack(&decompressed)?;
+
+        Ok(res)
+    }
+
+    pub fn params_from_regulation(bytes: &[u8]) -> Result<HashMap<Param, Vec<u8>>, Error>{
+        let res = Self::get_decrypted_decompressed(&bytes)?;
         let mut params: HashMap<Param, Vec<u8>> = HashMap::new();
 
         for file in &res.files {


### PR DESCRIPTION
As of the DLC release the regulation contents can no longer be used to compare to a checksum for identification.

This PR opts instead to attempt to decrypt and decompress the regulation contents such that if it succeeds the program assumes the file is the save wizard format. This is a bit slower than the checksum, but at least it's consistent!