### PR TITLE
Set `zoom_factor` only once

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ fn main() -> Result<(), eframe::Error> {
         visuals.window_rounding = Rounding::default().at_least(rounding);
         visuals.window_highlight_topmost = false;
         creation_context.egui_ctx.set_visuals(visuals);
+        creation_context.egui_ctx.set_zoom_factor(1.75);
         Box::new(App::new(creation_context))
     }))
 }
@@ -116,7 +117,6 @@ impl App {
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        ctx.set_zoom_factor(1.75);
         // TOP PANEL
         egui::TopBottomPanel::top("toolbar").default_height(35.).show(ctx, |ui| {
             ui.columns(2, |uis|{


### PR DESCRIPTION
Setting `zoom_factor` in `update()` prevents users from using the built-in zoom in/out functionality of `egui`, as the changes are overridden every frame.

This is fixed by setting the `zoom_factor` only during initialization.