### PR TITLE
Use fractional scaling instead of zooming. Also bug fixes..

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,16 +42,20 @@ fn main() -> Result<(), eframe::Error> {
     };
 
     eframe::run_native("ER Save Editor 0.0.21", options, Box::new(|creation_context| {
-        let mut fonts = egui::FontDefinitions::default();
-        egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
-        egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Fill);
-        creation_context.egui_ctx.set_fonts(fonts);
+        /*
+             Until compatibility for egui 0.28.2 reaches egui_phosphor there is a conflict of FontDefinitions..
+        */
+        
+        //let mut fonts = egui::FontDefinitions::default();
+        //egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+        //egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Fill);
+        //creation_context.egui_ctx.set_fonts(fonts);
         let mut visuals = creation_context.egui_ctx.style().visuals.clone();
         let rounding = 3.;
         visuals.window_rounding = Rounding::default().at_least(rounding);
         visuals.window_highlight_topmost = false;
         creation_context.egui_ctx.set_visuals(visuals);
-        Box::new(App::new(creation_context))
+        Ok(Box::new(App::new(creation_context)))
     }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,9 @@ impl App {
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        ctx.set_zoom_factor(1.75);
+        // Scale Gui to match fractional scaling of the OS
+        ctx.set_pixels_per_point(ctx.pixels_per_point());
+        //ctx.set_zoom_factor(1.75);
         // TOP PANEL
         egui::TopBottomPanel::top("toolbar").default_height(35.).show(ctx, |ui| {
             ui.columns(2, |uis|{

--- a/src/ui/inventory/add.rs
+++ b/src/ui/inventory/add.rs
@@ -377,7 +377,7 @@ fn single_item_customization(ui: &mut Ui, inventory_vm: &mut InventoryViewModel,
                         let item = res.unwrap();
                         let goods_type = GoodsType::from(item.data.goodsType);
                         let max_repository_num = if goods_type == GoodsType::KeyItem {item.data.maxNum} else {item.data.maxRepositoryNum};
-                        let field = egui::DragValue::new(regulation_vm.selected_item.quantity.as_mut().unwrap()).clamp_range(1..=max_repository_num);
+                        let field = egui::DragValue::new(regulation_vm.selected_item.quantity.as_mut().unwrap()).range(1..=max_repository_num);
                         ui.horizontal(|ui|{
                             let label = ui.label("Quantity");
                             ui.add(field).labelled_by(label.id);
@@ -393,7 +393,7 @@ fn single_item_customization(ui: &mut Ui, inventory_vm: &mut InventoryViewModel,
                         
                             if wep_type == WepType::Arrow || wep_type == WepType::Greatarrow || wep_type == WepType::Bolt || wep_type == WepType::BallistaBolt  {
                                 ui.horizontal(|ui|{
-                                    let field = egui::DragValue::new(regulation_vm.selected_item.quantity.as_mut().unwrap()).clamp_range(1..=item.data.maxArrowQuantity);
+                                    let field = egui::DragValue::new(regulation_vm.selected_item.quantity.as_mut().unwrap()).range(1..=item.data.maxArrowQuantity);
                                     let label = ui.label("Quantity");
                                     ui.add(field).labelled_by(label.id);
                                 });
@@ -407,7 +407,7 @@ fn single_item_customization(ui: &mut Ui, inventory_vm: &mut InventoryViewModel,
                                     item.data.reinforceTypeId % 8300 == 0 ||
                                     item.data.reinforceTypeId % 8500 == 0) {10} else {25};
                                 let field = egui::DragValue::new(regulation_vm.selected_item.upgrade.as_mut().unwrap())
-                                .clamp_range(0..=max_upgrade)
+                                .range(0..=max_upgrade)
                                 .custom_formatter(|n, _| {
                                     format!("+{}", n)
                                 });
@@ -467,13 +467,13 @@ fn bulk_item_customization(ui: &mut Ui, inventory_vm: &mut InventoryViewModel) {
             }
             InventoryTypeRoute::Weapons => {
                 egui::Grid::new("bulk_items_customization").spacing(Vec2::new(6., 6.)).show(ui,|ui| {
-                    let field = egui::DragValue::new(&mut inventory_vm.bulk_items_arrow_quantity).clamp_range(1..=99);
+                    let field = egui::DragValue::new(&mut inventory_vm.bulk_items_arrow_quantity).range(1..=99);
                     let label = ui.label("Projectile Quantity");
                     ui.add(field).labelled_by(label.id);
                     ui.end_row();
 
                     let label = ui.label("Weapon Level:");
-                    ui.add(egui::DragValue::new(&mut inventory_vm.bulk_items_weapon_level).clamp_range(0..=25).custom_formatter(|val, _| {
+                    ui.add(egui::DragValue::new(&mut inventory_vm.bulk_items_weapon_level).range(0..=25).custom_formatter(|val, _| {
                         let somber_upgrade_level: f64 = (val + 0.5)/2.5;
                         format!("Normal: +{}\t Somber: +{}", val as u32, somber_upgrade_level as u32)
                     })).labelled_by(label.id);

--- a/src/ui/inventory/browse.rs
+++ b/src/ui/inventory/browse.rs
@@ -102,7 +102,7 @@ pub fn browse_inventory(ui: &mut Ui, vm:&mut ViewModel) {
             for i in row_range {
                 let item = &current_inventory_list[i];
                 ui.label(format!("{}",item.item_id));
-                ui.add(egui::Label::new(item.item_name.to_string()).wrap(true));
+                ui.add(egui::Label::new(item.item_name.to_string()).wrap());
                 ui.label(format!("{}",item.quantity));
                 ui.label(format!("{}",item.inventory_index));
                 ui.end_row();

--- a/src/ui/inventory/inventory.rs
+++ b/src/ui/inventory/inventory.rs
@@ -17,7 +17,7 @@ pub mod inventory {
                         vm.slots[vm.index].inventory_vm.current_route = InventoryRoute::Add
                     }
                     if add_items.hovered() {
-                        egui::popup::show_tooltip(ui.ctx(), add_items.id, |ui|{
+                        add_items.show_tooltip_ui(|ui| {
                             ui.label(egui::RichText::new("Warning: This is an experimental feature that is still being worked on. Use with catution.").size(8.0).color(Color32::PLACEHOLDER));
                         });
                     }

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -60,7 +60,7 @@ pub mod stats {
 
                         // Souls
                         let field = egui::widgets::DragValue::new(&mut vm.slots[vm.index].stats_vm.souls)
-                            .clamp_range(0..=999999999)
+                            .range(0..=999999999)
                             .custom_formatter(|n, _|{
                                 format!("{:09}", n)
                             });

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -79,7 +79,7 @@ pub mod stats {
     }
 
     fn stat_field(body: &mut TableBody, range: RangeInclusive<u32>, name: &str, value: &mut u32) {
-        let field = egui::widgets::DragValue::new(value).clamp_range(range);
+        let field = egui::widgets::DragValue::new(value).range(range);
         body.row(24., |mut row| {
             row.col(|ui| {
                 ui.label(name);


### PR DESCRIPTION
### UI Scaling
Make the UI much more legible and makes use of personal preference instead of zooming.
If the goal is to have very large buttons and text, I propose of using text scaling instead of zooming to increase legibility. I can write up those changes and add them to the this draft as well.


Before:
![image](https://github.com/user-attachments/assets/9ffd1fa6-be54-453b-a75a-b4d23c06aaab)


After:
![image](https://github.com/user-attachments/assets/5e042285-5888-48e7-ada8-cf2fc1e9e701)


### Bug Fixes
To fix the UI from jittering while resizing, use the latest git version of egui instead of the latest release.

### Other
We _could_ add an options menu to house a slider for the UI scaling and / or a checkbox to just follow the OS scale.


I'm keeping this as a draft until the maintainers review to see if this is something they'd like to add. 