### PR TITLE
Open DLC 1.14 patch PS4, save wizard save game

### DIFF
--- a/src/save/common/user_data_11.rs
+++ b/src/save/common/user_data_11.rs
@@ -13,8 +13,8 @@ impl Default for UserData11 {
     fn default() -> Self {
         Self { 
             unk: Default::default(), 
-            regulation: vec![0; 0x1F0DE0],
-            rest: vec![0;0x4F220]
+            regulation: vec![0; 0x1F1240],
+            rest: vec![0;0x4EDC0]
         }
     }
 }
@@ -23,8 +23,8 @@ impl Read for UserData11 {
     fn read(br: &mut BinaryReader) -> Result<UserData11, Error> {
         let mut user_data_11 = UserData11::default();
         user_data_11.unk.copy_from_slice(br.read_bytes(0x10)?);
-        user_data_11.regulation.copy_from_slice(br.read_bytes(0x1F0DE0)?);
-        user_data_11.rest.copy_from_slice(br.read_bytes(0x4F220)?);
+        user_data_11.regulation.copy_from_slice(br.read_bytes(0x1F1240)?);
+        user_data_11.rest.copy_from_slice(br.read_bytes(0x4EDC0)?);
         assert_eq!(user_data_11.rest[0], 0);
         Ok(user_data_11)
     }

--- a/src/save/common/user_data_11.rs
+++ b/src/save/common/user_data_11.rs
@@ -13,8 +13,8 @@ impl Default for UserData11 {
     fn default() -> Self {
         Self { 
             unk: Default::default(), 
-            regulation: vec![0; 0x1e9fb0],
-            rest: vec![0;0x56050]
+            regulation: vec![0; 0x1ee6c0],
+            rest: vec![0;0x51940]
         }
     }
 }
@@ -23,8 +23,8 @@ impl Read for UserData11 {
     fn read(br: &mut BinaryReader) -> Result<UserData11, Error> {
         let mut user_data_11 = UserData11::default();
         user_data_11.unk.copy_from_slice(br.read_bytes(0x10)?);
-        user_data_11.regulation.copy_from_slice(br.read_bytes(0x1e9fb0)?);
-        user_data_11.rest.copy_from_slice(br.read_bytes(0x56050)?);
+        user_data_11.regulation.copy_from_slice(br.read_bytes(0x1ee6c0)?);
+        user_data_11.rest.copy_from_slice(br.read_bytes(0x51940)?);
         assert_eq!(user_data_11.rest[0], 0);
         Ok(user_data_11)
     }

--- a/src/save/common/user_data_11.rs
+++ b/src/save/common/user_data_11.rs
@@ -13,8 +13,8 @@ impl Default for UserData11 {
     fn default() -> Self {
         Self { 
             unk: Default::default(), 
-            regulation: vec![0; 0x1ee6c0],
-            rest: vec![0;0x51940]
+            regulation: vec![0; 0x1F0DE0],
+            rest: vec![0;0x4F220]
         }
     }
 }
@@ -23,8 +23,8 @@ impl Read for UserData11 {
     fn read(br: &mut BinaryReader) -> Result<UserData11, Error> {
         let mut user_data_11 = UserData11::default();
         user_data_11.unk.copy_from_slice(br.read_bytes(0x10)?);
-        user_data_11.regulation.copy_from_slice(br.read_bytes(0x1ee6c0)?);
-        user_data_11.rest.copy_from_slice(br.read_bytes(0x51940)?);
+        user_data_11.regulation.copy_from_slice(br.read_bytes(0x1F0DE0)?);
+        user_data_11.rest.copy_from_slice(br.read_bytes(0x4F220)?);
         assert_eq!(user_data_11.rest[0], 0);
         Ok(user_data_11)
     }

--- a/src/save/save.rs
+++ b/src/save/save.rs
@@ -826,7 +826,7 @@ pub mod save {
         // Check if it's a PS Save Wizard save file
         pub fn is_ps_save_wizard(br: &mut BinaryReader) -> bool {
             br.jmp(0x1960080);
-            let regulation = br.read_bytes(0x1ee6c0).expect("");
+            let regulation = br.read_bytes(0x1F0DE0 ).expect("");
             let is_ps_save_wizard = match Regulation::get_decrypted_decompressed(&regulation) {
                 Ok(_v) => true,
                 Err(_e) => false,

--- a/src/save/save.rs
+++ b/src/save/save.rs
@@ -826,7 +826,7 @@ pub mod save {
         // Check if it's a PS Save Wizard save file
         pub fn is_ps_save_wizard(br: &mut BinaryReader) -> bool {
             br.jmp(0x1960080);
-            let regulation = br.read_bytes(0x1F0DE0).expect("");
+            let regulation = br.read_bytes(0x1F1240).expect("");
             let is_ps_save_wizard = match Regulation::get_decrypted_decompressed(&regulation) {
                 Ok(_v) => true,
                 Err(_e) => false,

--- a/src/save/save.rs
+++ b/src/save/save.rs
@@ -6,11 +6,11 @@ pub mod save {
             common::{ save_slot::{EquipInventoryData, EquipProjectileData, GaItem, GaItemData, SaveSlot}, user_data_10::ProfileSummary, user_data_11::UserData11 },
             pc::pc_save::PCSave, 
             playstation::ps_save::PSSave, 
-        }, util::bit::bit::set_bit, write::write::Write
+        }, util::{bit::bit::set_bit, regulation::Regulation}, write::write::Write
     };
 
     // Using a checksum of the regulation bin file to check for Save Wizard .txt save file
-    const REGULATION_MD5_CHECKSUM: [u8; 0x10] =[0x2E, 0x88, 0x1A, 0x15, 0xAC, 0x05, 0x88, 0x8D, 0xF2, 0xC2, 0x6A, 0xEC, 0xC2, 0x90, 0x89, 0x23];
+    // const REGULATION_MD5_CHECKSUM: [u8; 0x10] =[0x2E, 0x88, 0x1A, 0x15, 0xAC, 0x05, 0x88, 0x8D, 0xF2, 0xC2, 0x6A, 0xEC, 0xC2, 0x90, 0x89, 0x23];
 
     pub enum SaveType {
         Unknown,
@@ -825,10 +825,12 @@ pub mod save {
 
         // Check if it's a PS Save Wizard save file
         pub fn is_ps_save_wizard(br: &mut BinaryReader) -> bool {
-            br.jmp(0x1960070);
-            let regulation = br.read_bytes(0x240010).expect("");
-            let digest = md5::compute(regulation);
-            let is_ps_save_wizard = digest == md5::Digest(REGULATION_MD5_CHECKSUM);
+            br.jmp(0x1960080);
+            let regulation = br.read_bytes(0x1ee6c0).expect("");
+            let is_ps_save_wizard = match Regulation::get_decrypted_decompressed(&regulation) {
+                Ok(_v) => true,
+                Err(_e) => false,
+            };
             br.jmp(0);
             is_ps_save_wizard
         }

--- a/src/save/save.rs
+++ b/src/save/save.rs
@@ -826,7 +826,7 @@ pub mod save {
         // Check if it's a PS Save Wizard save file
         pub fn is_ps_save_wizard(br: &mut BinaryReader) -> bool {
             br.jmp(0x1960080);
-            let regulation = br.read_bytes(0x1F0DE0 ).expect("");
+            let regulation = br.read_bytes(0x1F0DE0).expect("");
             let is_ps_save_wizard = match Regulation::get_decrypted_decompressed(&regulation) {
                 Ok(_v) => true,
                 Err(_e) => false,

--- a/src/util/regulation.rs
+++ b/src/util/regulation.rs
@@ -87,6 +87,14 @@ impl Regulation {
         });
     }
 
+    pub fn get_decrypted_decompressed(bytes: &[u8]) -> Result<BND4, Error>{
+        let decrypted = Self::decrypt(&bytes)?;
+        let decompressed = Self::decompress(&decrypted)?;
+        let res = Self::unpack(&decompressed)?;
+
+        Ok(res)
+    }
+
     pub fn params_from_regulation(bytes: &[u8]) -> Result<HashMap<Param, Vec<u8>>, Error>{
         let decrypted = Self::decrypt(&bytes)?;
         let decompressed = Self::decompress(&decrypted)?;


### PR DESCRIPTION
This is just an update regarding [Pull Request #57](https://github.com/ClayAmore/ER-Save-Editor/pull/57) on this repo. The PR is  for opening PS4 save games from the 1.13.2 DLC patch using SaveWizard. I noticed that @ClayAmore is writting a big refactor, this PR is just to help others to open their PS4 save games as temp workaround.

Thanks!